### PR TITLE
Required changes for React Native 0.29.0

### DIFF
--- a/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -48,12 +48,10 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
     private AirMapCircleManager circleManager;
 
     public AirMapManager(
-            Activity activity,
             AirMapMarkerManager markerManager,
             AirMapPolylineManager polylineManager,
             AirMapPolygonManager polygonManager,
             AirMapCircleManager circleManager) {
-        this.reactActivity = activity;
         this.markerManager = markerManager;
         this.polylineManager = polylineManager;
         this.polygonManager = polygonManager;
@@ -70,12 +68,12 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
         reactContext = context;
 
         try {
-            MapsInitializer.initialize(reactActivity);
+            MapsInitializer.initialize(reactContext);
         } catch (Exception e) {
             e.printStackTrace();
             emitMapError("Map initialize error", "map_init_error");
         }
-        AirMapView view = new AirMapView(context, reactActivity, this);
+        AirMapView view = new AirMapView(context, this);
 
         return view;
     }

--- a/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/android/lib/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -88,8 +88,8 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
 
     final EventDispatcher eventDispatcher;
 
-    public AirMapView(ThemedReactContext context, Activity activity, AirMapManager manager) {
-        super(activity);
+    public AirMapView(ThemedReactContext context, AirMapManager manager) {
+        super(context);
         this.manager = manager;
         this.context = context;
 

--- a/android/lib/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
+++ b/android/lib/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
@@ -13,11 +13,6 @@ import java.util.Collections;
 import java.util.List;
 
 public class MapsPackage implements ReactPackage {
-    private Activity reactActivity = null;
-
-    public MapsPackage(Activity activity) {
-        reactActivity = activity;
-    }
 
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
@@ -37,7 +32,6 @@ public class MapsPackage implements ReactPackage {
         AirMapPolygonManager polygonManager = new AirMapPolygonManager(reactContext);
         AirMapCircleManager circleManager = new AirMapCircleManager(reactContext);
         AirMapManager mapManager = new AirMapManager(
-                reactActivity,
                 annotationManager,
                 polylineManager,
                 polygonManager,


### PR DESCRIPTION
See Breaking Change @ https://github.com/facebook/react-native/releases/tag/v0.29.0

I noticed activity was being passed down in order to call `MapsInitializer.initialize` but that method required context and not activity.
I'm not sure how it worked without the compiler complaining.

After passing the context and making sure everything worked, there was no need for activity so removing it fixed the issue with RN 0.29.0
